### PR TITLE
fix jade doctype

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html(ng-app='chatspace')
   head
     title chatspaces


### PR DESCRIPTION
Upon installing chatspaces and running it for the first time, I encountered the following error:

```
`!!! 5` is deprecated, you must now use `doctype html`
    at Object.Compiler.setDoctype (~/Development/chatspaces/node_modules/jade/lib/compiler.js:68:13)
    at Object.Compiler.visitDoctype (~/Development/chatspaces/node_modules/jade/lib/compiler.js:312:12)
    at Object.Compiler.visitNode (~/Development/chatspaces/node_modules/jade/lib/compiler.js:210:37)
    at Object.Compiler.visit (~/Development/chatspaces/node_modules/jade/lib/compiler.js:197:10)
    at Object.Compiler.visitBlock (~/Development/chatspaces/node_modules/jade/lib/compiler.js:278:12)
    at Object.Compiler.visitNode (~/Development/chatspaces/node_modules/jade/lib/compiler.js:210:37)
    at Object.Compiler.visit (~/Development/chatspaces/node_modules/jade/lib/compiler.js:197:10)
    at Object.Compiler.compile (~/Development/chatspaces/node_modules/jade/lib/compiler.js:52:10)
    at parse (~/Development/chatspaces/node_modules/jade/lib/jade.js:96:23)
    at Object.exports.compile (~/Development/chatspaces/node_modules/jade/lib/jade.js:152:9)
```

Apparently `!!! 5` isn't a thing in Jade anymore in `1.0.0`.

It might be worth restricting `jade` in `package.json` to `~1.0.0` to avoid surprises like this in the future.
