### PR TITLE
updated gumHelper to use version without default timeout

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "animated-gif": "sole/Animated_GIF#38c7e30965578591de0f9dbbc87829f9259fd289",
     "angular": "1.2.0",
     "angular-route": "1.2.0",
-    "gumhelper": "sole/gumhelper#8f344dc27605fb9ee063c911f8bd5fc47b9300b4",
+    "gumhelper": "sole/gumhelper#596ddfb555039a400b8287fc5ac01f0b2aebf6fa",
     "moment": "2.4.0",
     "localforage": "mozilla/localForage#00c9d5f6db247a623c3e4f92a7c0e0d4ffbc8bbf",
     "angular-translate": "1.1.1",


### PR DESCRIPTION
Not much of a problem now I think, but this will make things more predictable?
